### PR TITLE
Removed use of array and readlink

### DIFF
--- a/telegram-send.sh
+++ b/telegram-send.sh
@@ -1,16 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-arr=()
-SAVEIFS=$IFS
-IFS=$(echo -en "\n\b")
-
-for var in "$@"
-do
-    path=$(readlink -f $var)
-    arr+=($path)
-done
-
-telegram-desktop -sendpath "${arr[@]}"
+telegram-desktop -sendpath "$@"
 wmctrl -x -a Telegram.TelegramDesktop
-
-IFS=$SAVEIFS


### PR DESCRIPTION
Since nemo passes us the full file path, we don't need to use readlink which was used to get the full path.
Also due to this, we could remove the use of the array and pass the arguments directly to the command

this PR also changes shell from bash to sh 